### PR TITLE
feat: add US3 package install smoke workflow and docs

### DIFF
--- a/.github/workflows/package-install-smoke.yml
+++ b/.github/workflows/package-install-smoke.yml
@@ -1,0 +1,195 @@
+name: Package Install Smoke
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag to validate (e.g., v1.2.3). Empty = latest tag.'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  build-package-artifacts:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      artifact_name: ${{ steps.meta.outputs.artifact_name }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Resolve smoke version
+      id: meta
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+          version="${{ inputs.version }}"
+          if [ -z "${version}" ]; then
+            version="$(git describe --tags --abbrev=0 2>/dev/null || echo "")"
+          fi
+        else
+          version="${GITHUB_REF#refs/tags/}"
+        fi
+
+        if [ -z "${version}" ]; then
+          echo "Could not resolve release version." >&2
+          exit 1
+        fi
+
+        artifact_name="package-install-smoke-dist-${version}"
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+        echo "artifact_name=${artifact_name}" >> "$GITHUB_OUTPUT"
+
+    - name: Checkout smoke version
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ steps.meta.outputs.version }}
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24.11'
+
+    - name: Cache Go modules
+      uses: actions/cache@v4
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Install dependencies
+      run: go mod download
+
+    - name: Install packaging tools
+      run: |
+        echo "${HOME}/go/bin" >> "$GITHUB_PATH"
+        go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.43.1
+        nfpm --version
+        pwsh --version
+
+    - name: Build package artifacts for smoke tests
+      run: |
+        chmod +x scripts/packaging/ci/smoke_us1.sh
+        scripts/packaging/ci/smoke_us1.sh \
+          --version "${{ steps.meta.outputs.version }}" \
+          --dist-dir dist
+
+    - name: Upload smoke artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.meta.outputs.artifact_name }}
+        path: dist/
+
+  install-smoke:
+    needs: build-package-artifacts
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - manager: apt
+            runner: ubuntu-latest
+            label: ubuntu
+          - manager: dnf
+            runner: ubuntu-latest
+            label: fedora
+          - manager: brew
+            runner: macos-latest
+            label: macos
+          - manager: choco
+            runner: windows-latest
+            label: windows
+    runs-on: ${{ matrix.runner }}
+    name: install-smoke-${{ matrix.label }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download smoke artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ needs.build-package-artifacts.outputs.artifact_name }}
+        path: dist
+
+    - name: Normalize artifact layout (unix)
+      if: matrix.manager != 'choco'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -f dist/dist/release-manifest.json ] && [ ! -f dist/release-manifest.json ]; then
+          cp -R dist/dist/. dist/
+          find dist/dist -mindepth 1 -delete
+          rmdir dist/dist
+        fi
+
+    - name: Normalize artifact layout (windows)
+      if: matrix.manager == 'choco'
+      shell: pwsh
+      run: |
+        if ((Test-Path "dist/dist/release-manifest.json") -and (-not (Test-Path "dist/release-manifest.json"))) {
+          Copy-Item -Path "dist/dist/*" -Destination "dist" -Recurse -Force
+          Remove-Item -Path "dist/dist" -Recurse -Force
+        }
+
+    - name: Run apt install smoke test
+      if: matrix.manager == 'apt'
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y apt-utils gpg
+        chmod +x scripts/packaging/ci/smoke_apt.sh scripts/packaging/publish_apt_repo.sh
+        scripts/packaging/ci/smoke_apt.sh \
+          --manifest dist/release-manifest.json \
+          --dist-dir dist
+
+    - name: Run dnf install smoke test
+      if: matrix.manager == 'dnf'
+      shell: bash
+      run: |
+        set -euo pipefail
+        docker run --rm \
+          -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
+          -w "${GITHUB_WORKSPACE}" \
+          fedora:41 \
+          bash -lc '
+            set -euo pipefail
+            dnf -y install git jq sudo createrepo_c gnupg2
+            chmod +x scripts/packaging/ci/smoke_dnf.sh scripts/packaging/publish_dnf_repo.sh
+            scripts/packaging/ci/smoke_dnf.sh \
+              --manifest dist/release-manifest.json \
+              --dist-dir dist
+          '
+
+    - name: Run brew install smoke test
+      if: matrix.manager == 'brew'
+      shell: bash
+      run: |
+        set -euo pipefail
+        brew list jq >/dev/null 2>&1 || brew install jq
+        chmod +x \
+          scripts/packaging/ci/smoke_brew.sh \
+          scripts/packaging/generate_release_manifest.sh \
+          scripts/packaging/render_homebrew_formula.sh \
+          scripts/packaging/normalize_version.sh
+        scripts/packaging/ci/smoke_brew.sh \
+          --manifest dist/release-manifest.json \
+          --dist-dir dist
+
+    - name: Run choco install smoke test
+      if: matrix.manager == 'choco'
+      shell: pwsh
+      run: |
+        ./scripts/packaging/ci/smoke_choco.ps1 `
+          -ManifestPath "dist/release-manifest.json" `
+          -DistDir "dist"
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,7 @@ jobs:
       env:
         VERSION: ${{ steps.version.outputs.VERSION }}
       run: |
+        REPO_OWNER="${GITHUB_REPOSITORY%%/*}"
         cat > release_notes.md << EOF
         # surveiller ${VERSION}
         
@@ -191,6 +192,41 @@ jobs:
         fi)
         
         ## Installation
+
+        ### Package Managers
+
+        \`\`\`bash
+        # apt
+        sudo tee /etc/apt/sources.list.d/surveiller.list >/dev/null <<'APT'
+        deb [trusted=yes] <apt-repo-url> stable main
+        APT
+        sudo apt update
+        sudo apt install -y surveiller
+
+        # dnf
+        sudo tee /etc/yum.repos.d/surveiller.repo >/dev/null <<'DNF'
+        [surveiller]
+        name=surveiller
+        baseurl=<dnf-repo-url>/packages
+        enabled=1
+        gpgcheck=0
+        repo_gpgcheck=0
+        DNF
+        sudo dnf makecache
+        sudo dnf install -y surveiller
+
+        # Homebrew
+        brew tap ${REPO_OWNER}/homebrew-tap
+        brew install ${REPO_OWNER}/homebrew-tap/surveiller
+        \`\`\`
+
+        \`\`\`powershell
+        # Chocolatey community feed
+        choco install surveiller -y
+
+        # or private feed
+        choco install surveiller -y --source="'<choco-feed-url>'"
+        \`\`\`
         
         ### Quick Install (Linux/macOS)
         

--- a/.kiro/specs/multi-package-manager-install/tasks.md
+++ b/.kiro/specs/multi-package-manager-install/tasks.md
@@ -67,14 +67,14 @@ Story goal:
 Independent test criteria:
 install smoke test workflow が Ubuntu/Fedora/macOS/Windows の各ジョブで `surveiller -version` を成功させること。README と Release notes に4マネージャの install コマンドが記載されること。
 
-- [ ] T025 [US3] Create install smoke-test matrix workflow in `.github/workflows/package-install-smoke.yml`
-- [ ] T026 [P] [US3] Add apt smoke test script in `scripts/packaging/ci/smoke_apt.sh`
-- [ ] T027 [P] [US3] Add dnf smoke test script in `scripts/packaging/ci/smoke_dnf.sh`
-- [ ] T028 [P] [US3] Add brew smoke test script in `scripts/packaging/ci/smoke_brew.sh`
-- [ ] T029 [P] [US3] Add choco smoke test script in `scripts/packaging/ci/smoke_choco.ps1`
-- [ ] T030 [US3] Add package-manager installation section in `README.md`
-- [ ] T031 [US3] Add package publication operation guide in `docs/RELEASE.md`
-- [ ] T032 [US3] Update release notes generation block in `.github/workflows/release.yml`
+- [x] T025 [US3] Create install smoke-test matrix workflow in `.github/workflows/package-install-smoke.yml`
+- [x] T026 [P] [US3] Add apt smoke test script in `scripts/packaging/ci/smoke_apt.sh`
+- [x] T027 [P] [US3] Add dnf smoke test script in `scripts/packaging/ci/smoke_dnf.sh`
+- [x] T028 [P] [US3] Add brew smoke test script in `scripts/packaging/ci/smoke_brew.sh`
+- [x] T029 [P] [US3] Add choco smoke test script in `scripts/packaging/ci/smoke_choco.ps1`
+- [x] T030 [US3] Add package-manager installation section in `README.md`
+- [x] T031 [US3] Add package publication operation guide in `docs/RELEASE.md`
+- [x] T032 [US3] Update release notes generation block in `.github/workflows/release.yml`
 
 ## Final Phase: Polish & Cross-Cutting
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,53 @@ Download the latest release from the [releases page](https://github.com/doridori
 
 **Note**: macOS and Windows builds are provided as experimental releases. While basic functionality has been verified, these platforms are not part of our continuous testing pipeline. Community feedback and contributions for platform-specific issues are welcome.
 
+### Package Manager Installation
+
+Package-manager distribution is supported for `apt`, `dnf`, `brew`, and `choco`.
+Replace placeholder values with your published repository/tap/feed endpoints.
+
+#### APT (Debian/Ubuntu)
+
+```bash
+sudo tee /etc/apt/sources.list.d/surveiller.list >/dev/null <<'EOF'
+deb [trusted=yes] <apt-repo-url> stable main
+EOF
+sudo apt update
+sudo apt install -y surveiller
+```
+
+#### DNF (Fedora/RHEL family)
+
+```bash
+sudo tee /etc/yum.repos.d/surveiller.repo >/dev/null <<'EOF'
+[surveiller]
+name=surveiller
+baseurl=<dnf-repo-url>/packages
+enabled=1
+gpgcheck=0
+repo_gpgcheck=0
+EOF
+sudo dnf makecache
+sudo dnf install -y surveiller
+```
+
+#### Homebrew (macOS/Linux)
+
+```bash
+brew tap <owner>/homebrew-tap
+brew install <owner>/homebrew-tap/surveiller
+```
+
+#### Chocolatey (Windows)
+
+```powershell
+# Chocolatey community feed
+choco install surveiller -y
+
+# or private feed
+choco install surveiller -y --source="'<choco-feed-url>'"
+```
+
 ### Build from Source
 
 ```bash

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -106,6 +106,56 @@ The GitHub Actions workflow (`.github/workflows/release.yml`) handles:
 4. **Release Notes**: Creates installation instructions
 5. **Publishing**: Creates GitHub release with all artifacts
 
+## Package Publication Operations
+
+Package publication is handled by `.github/workflows/publish-packages.yml`.
+
+### Required Secrets
+
+- `APT_GPG_PRIVATE_KEY` (+ optional `APT_GPG_PASSPHRASE`)
+- `RPM_GPG_PRIVATE_KEY` (+ optional `RPM_GPG_PASSPHRASE`)
+- `HOMEBREW_TAP_PUSH_TOKEN`
+- `CHOCO_API_KEY`
+
+### Recommended Procedure
+
+1. Run package publication in dry-run mode:
+   - GitHub Actions -> `Publish Packages` -> `Run workflow`
+   - `dry_run=true`
+   - `managers=apt,dnf,brew,choco`
+2. Verify `publication-status-summary` artifacts:
+   - `summary.json`
+   - `summary.md`
+3. Run live publication:
+   - Re-run workflow with `dry_run=false`
+4. Verify package install smoke matrix:
+   - Run `.github/workflows/package-install-smoke.yml`
+   - Confirm all jobs pass (`apt`, `dnf`, `brew`, `choco`)
+
+### Homebrew/Chocolatey Targets
+
+- Homebrew tap target is controlled by:
+  - `HOMEBREW_TAP_REPO` (e.g. `owner/homebrew-tap`)
+  - `HOMEBREW_TAP_PUSH` (`true` to push after formula commit)
+- Chocolatey source target is controlled by:
+  - `CHOCO_SOURCE_URL` (default: `https://push.chocolatey.org/`)
+
+### Local Verification Commands
+
+```bash
+# Linux package publication checks
+./scripts/packaging/publish_apt_repo.sh --version v0.0.1 --dry-run true
+./scripts/packaging/publish_dnf_repo.sh --version v0.0.1 --dry-run true
+
+# Homebrew publication check
+./scripts/packaging/publish_homebrew_tap.sh --version v0.0.1 --dry-run true
+```
+
+```powershell
+# Chocolatey publication check
+pwsh -File ./scripts/packaging/publish_choco_package.ps1 -Version v0.0.1 -DryRun true
+```
+
 ## Pre-release Testing
 
 Before creating a release:

--- a/scripts/packaging/ci/smoke_apt.sh
+++ b/scripts/packaging/ci/smoke_apt.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=scripts/packaging/lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  smoke_apt.sh [options]
+
+Options:
+  --manifest <path>       Release manifest path (default: dist/release-manifest.json)
+  --dist-dir <path>       Dist directory (default: dist)
+  --repo-dir <path>       APT repo output directory (default: <dist>/published/apt-smoke)
+  --status-file <path>    Publish status path (default: <dist>/publication-status/smoke-apt.json)
+  --package <name>        Package name to install (default: surveiller)
+  --attempt <number>      Attempt number for status payload (default: 1)
+  -h, --help              Show this help
+EOF
+}
+
+to_abs_path() {
+  local repo_root="$1"
+  local path="$2"
+  case "${path}" in
+    /*) printf '%s\n' "${path}" ;;
+    *) printf '%s\n' "${repo_root}/${path}" ;;
+  esac
+}
+
+run_as_root() {
+  if command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    "$@"
+  fi
+}
+
+main() {
+  local repo_root manifest_path dist_dir repo_dir status_file package_name attempt
+  local manifest_abs dist_abs repo_abs status_abs publish_script version source_list
+
+  repo_root="$(packaging_repo_root)"
+  manifest_path="dist/release-manifest.json"
+  dist_dir="dist"
+  repo_dir=""
+  status_file=""
+  package_name="surveiller"
+  attempt="${ATTEMPT:-1}"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --manifest)
+        manifest_path="${2:-}"
+        shift 2
+        ;;
+      --dist-dir)
+        dist_dir="${2:-}"
+        shift 2
+        ;;
+      --repo-dir)
+        repo_dir="${2:-}"
+        shift 2
+        ;;
+      --status-file)
+        status_file="${2:-}"
+        shift 2
+        ;;
+      --package)
+        package_name="${2:-}"
+        shift 2
+        ;;
+      --attempt)
+        attempt="${2:-}"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        packaging_die "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  if [ -z "${repo_dir}" ]; then
+    repo_dir="${dist_dir}/published/apt-smoke"
+  fi
+  if [ -z "${status_file}" ]; then
+    status_file="${dist_dir}/publication-status/smoke-apt.json"
+  fi
+
+  manifest_abs="$(to_abs_path "${repo_root}" "${manifest_path}")"
+  dist_abs="$(to_abs_path "${repo_root}" "${dist_dir}")"
+  repo_abs="$(to_abs_path "${repo_root}" "${repo_dir}")"
+  status_abs="$(to_abs_path "${repo_root}" "${status_file}")"
+  publish_script="${SCRIPT_DIR}/../publish_apt_repo.sh"
+
+  packaging_require_file "${manifest_abs}"
+  packaging_require_executable "${publish_script}"
+  packaging_require_command jq
+  packaging_require_command apt-get
+  packaging_require_command apt-ftparchive
+
+  version="$(jq -r '.version // empty' "${manifest_abs}")"
+  [ -n "${version}" ] || packaging_die "manifest missing version"
+
+  "${publish_script}" \
+    --version "${version}" \
+    --manifest "${manifest_abs}" \
+    --dist-dir "${dist_abs}" \
+    --repo-dir "${repo_abs}" \
+    --dry-run false \
+    --attempt "${attempt}" \
+    --status-file "${status_abs}"
+
+  source_list="/etc/apt/sources.list.d/surveiller-smoke.list"
+  cleanup() {
+    run_as_root rm -f "${source_list}" || true
+  }
+  trap cleanup EXIT
+
+  printf 'deb [trusted=yes] file:%s stable main\n' "${repo_abs}" | run_as_root tee "${source_list}" >/dev/null
+
+  run_as_root apt-get update
+  run_as_root apt-get install -y "${package_name}"
+
+  "${package_name}" -version >/dev/null
+  packaging_log_info "apt smoke install passed for package ${package_name}"
+}
+
+main "$@"
+

--- a/scripts/packaging/ci/smoke_brew.sh
+++ b/scripts/packaging/ci/smoke_brew.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=scripts/packaging/lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  smoke_brew.sh [options]
+
+Options:
+  --manifest <path>        Release manifest path (default: dist/release-manifest.json)
+  --dist-dir <path>        Dist directory (default: dist)
+  --manifest-out <path>    Local manifest output path (default: <dist>/release-manifest.brew-smoke.json)
+  --formula-out <path>     Local formula output path (default: <dist>/packages/homebrew/surveiller.smoke.rb)
+  --tap-path <path>        Local tap path (default: <dist>/published/homebrew-tap-smoke)
+  --tap-name <name>        Brew tap name (default: surveiller/tap-smoke)
+  --package <name>         Formula package name (default: surveiller)
+  -h, --help               Show this help
+EOF
+}
+
+to_abs_path() {
+  local repo_root="$1"
+  local path="$2"
+  case "${path}" in
+    /*) printf '%s\n' "${path}" ;;
+    *) printf '%s\n' "${repo_root}/${path}" ;;
+  esac
+}
+
+main() {
+  local repo_root manifest_path dist_dir local_manifest_path formula_out tap_path tap_name package_name
+  local manifest_abs dist_abs local_manifest_abs formula_abs tap_abs
+  local generate_script render_script version commit_sha repository release_date release_base_url checksums_abs schema_abs
+
+  repo_root="$(packaging_repo_root)"
+  manifest_path="dist/release-manifest.json"
+  dist_dir="dist"
+  local_manifest_path=""
+  formula_out=""
+  tap_path=""
+  tap_name="${HOMEBREW_TAP_NAME:-surveiller/tap-smoke}"
+  package_name="surveiller"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --manifest)
+        manifest_path="${2:-}"
+        shift 2
+        ;;
+      --dist-dir)
+        dist_dir="${2:-}"
+        shift 2
+        ;;
+      --manifest-out)
+        local_manifest_path="${2:-}"
+        shift 2
+        ;;
+      --formula-out)
+        formula_out="${2:-}"
+        shift 2
+        ;;
+      --tap-path)
+        tap_path="${2:-}"
+        shift 2
+        ;;
+      --tap-name)
+        tap_name="${2:-}"
+        shift 2
+        ;;
+      --package)
+        package_name="${2:-}"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        packaging_die "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  if [ -z "${local_manifest_path}" ]; then
+    local_manifest_path="${dist_dir}/release-manifest.brew-smoke.json"
+  fi
+  if [ -z "${formula_out}" ]; then
+    formula_out="${dist_dir}/packages/homebrew/surveiller.smoke.rb"
+  fi
+  if [ -z "${tap_path}" ]; then
+    tap_path="${dist_dir}/published/homebrew-tap-smoke"
+  fi
+
+  manifest_abs="$(to_abs_path "${repo_root}" "${manifest_path}")"
+  dist_abs="$(to_abs_path "${repo_root}" "${dist_dir}")"
+  local_manifest_abs="$(to_abs_path "${repo_root}" "${local_manifest_path}")"
+  formula_abs="$(to_abs_path "${repo_root}" "${formula_out}")"
+  tap_abs="$(to_abs_path "${repo_root}" "${tap_path}")"
+
+  generate_script="${SCRIPT_DIR}/../generate_release_manifest.sh"
+  render_script="${SCRIPT_DIR}/../render_homebrew_formula.sh"
+  checksums_abs="${dist_abs}/checksums.txt"
+  schema_abs="${repo_root}/packaging/release-manifest.schema.json"
+
+  packaging_require_file "${manifest_abs}"
+  packaging_require_file "${checksums_abs}"
+  packaging_require_file "${schema_abs}"
+  packaging_require_executable "${generate_script}"
+  packaging_require_executable "${render_script}"
+  packaging_require_command brew
+  packaging_require_command jq
+  packaging_require_command git
+
+  version="$(jq -r '.version // empty' "${manifest_abs}")"
+  commit_sha="$(jq -r '.commit_sha // empty' "${manifest_abs}")"
+  repository="$(jq -r '.repository // empty' "${manifest_abs}")"
+  [ -n "${version}" ] || packaging_die "manifest missing version"
+  [ -n "${commit_sha}" ] || packaging_die "manifest missing commit_sha"
+  [ -n "${repository}" ] || packaging_die "manifest missing repository"
+
+  release_date="$(packaging_utc_now)"
+  release_base_url="file://${dist_abs}"
+
+  "${generate_script}" \
+    --version "${version}" \
+    --commit-sha "${commit_sha}" \
+    --release-date "${release_date}" \
+    --repository "${repository}" \
+    --release-base-url "${release_base_url}" \
+    --dist-dir "${dist_abs}" \
+    --checksums-file "${checksums_abs}" \
+    --schema "${schema_abs}" \
+    --output "${local_manifest_abs}"
+
+  "${render_script}" \
+    --manifest "${local_manifest_abs}" \
+    --dist-dir "${dist_abs}" \
+    --output "${formula_abs}" \
+    --checksums-file "${checksums_abs}"
+
+  rm -rf "${tap_abs}"
+  mkdir -p "${tap_abs}/Formula"
+  cp -f "${formula_abs}" "${tap_abs}/Formula/${package_name}.rb"
+
+  (
+    cd "${tap_abs}"
+    git init -q
+    git add "Formula/${package_name}.rb"
+    git -c user.name="surveiller-smoke" -c user.email="surveiller-smoke@local" commit -qm "smoke formula"
+  )
+
+  cleanup() {
+    brew uninstall --ignore-dependencies --force "${package_name}" >/dev/null 2>&1 || true
+    brew untap "${tap_name}" >/dev/null 2>&1 || true
+  }
+  trap cleanup EXIT
+
+  brew untap "${tap_name}" >/dev/null 2>&1 || true
+  brew tap "${tap_name}" "${tap_abs}"
+  brew install "${tap_name}/${package_name}"
+
+  "${package_name}" -version >/dev/null
+  packaging_log_info "brew smoke install passed for formula ${tap_name}/${package_name}"
+}
+
+main "$@"

--- a/scripts/packaging/ci/smoke_choco.ps1
+++ b/scripts/packaging/ci/smoke_choco.ps1
@@ -1,0 +1,126 @@
+#!/usr/bin/env pwsh
+
+param(
+  [string]$ManifestPath = "dist/release-manifest.json",
+  [string]$DistDir = "dist",
+  [string]$OutputDir = "",
+  [string]$PackageName = "surveiller"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Resolve-RepoRoot {
+  $repoRoot = & git rev-parse --show-toplevel 2>$null
+  if ($LASTEXITCODE -eq 0 -and $repoRoot) {
+    return $repoRoot.Trim()
+  }
+  return (Get-Location).Path
+}
+
+function Resolve-RepoPath {
+  param(
+    [string]$Root,
+    [string]$PathValue
+  )
+
+  if ([string]::IsNullOrWhiteSpace($PathValue)) {
+    return $PathValue
+  }
+  if ([System.IO.Path]::IsPathRooted($PathValue)) {
+    return $PathValue
+  }
+  return [System.IO.Path]::GetFullPath((Join-Path $Root $PathValue))
+}
+
+function Require-Command {
+  param([string]$Name)
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+    throw "required command is not installed: $Name"
+  }
+}
+
+$repoRoot = Resolve-RepoRoot
+$manifestAbs = Resolve-RepoPath -Root $repoRoot -PathValue $ManifestPath
+$distAbs = Resolve-RepoPath -Root $repoRoot -PathValue $DistDir
+
+if ([string]::IsNullOrWhiteSpace($OutputDir)) {
+  $OutputDir = Join-Path $DistDir "packages/choco-smoke"
+}
+$outputAbs = Resolve-RepoPath -Root $repoRoot -PathValue $OutputDir
+$checksumsAbs = Join-Path $distAbs "checksums.txt"
+$localManifestAbs = Join-Path $distAbs "release-manifest.choco-smoke.json"
+$buildScript = Join-Path $repoRoot "scripts/packaging/build_choco_package.ps1"
+
+if (-not (Test-Path $manifestAbs)) {
+  throw "required file not found: $manifestAbs"
+}
+if (-not (Test-Path $checksumsAbs)) {
+  throw "required file not found: $checksumsAbs"
+}
+if (-not (Test-Path $buildScript)) {
+  throw "required file not found: $buildScript"
+}
+
+Require-Command -Name "choco"
+
+$manifest = Get-Content -Path $manifestAbs -Raw | ConvertFrom-Json
+$version = [string]$manifest.version
+if ([string]::IsNullOrWhiteSpace($version)) {
+  throw "manifest missing version"
+}
+
+$windowsBinary = Join-Path $distAbs "surveiller-windows-amd64.exe"
+if (-not (Test-Path $windowsBinary)) {
+  throw "required file not found: $windowsBinary"
+}
+
+$chocoVersion = [string]$manifest.package_versions.choco
+if ([string]::IsNullOrWhiteSpace($chocoVersion)) {
+  throw "manifest missing package_versions.choco"
+}
+
+$manifestCopy = $manifest | ConvertTo-Json -Depth 50 | ConvertFrom-Json
+$windowsArtifact = $manifestCopy.artifacts | Where-Object { $_.name -eq "surveiller-windows-amd64.exe" } | Select-Object -First 1
+if ($null -eq $windowsArtifact) {
+  throw "manifest missing windows amd64 artifact"
+}
+
+$windowsBinaryUri = [System.Uri]::new($windowsBinary).AbsoluteUri
+$windowsArtifact.url = $windowsBinaryUri
+$manifestCopy.release_base_url = ([System.Uri]::new($distAbs + [System.IO.Path]::DirectorySeparatorChar)).AbsoluteUri.TrimEnd('/')
+$manifestCopy.release_date = [DateTime]::UtcNow.ToString("o")
+
+$manifestCopy | ConvertTo-Json -Depth 50 | Set-Content -Path $localManifestAbs -Encoding utf8
+
+New-Item -ItemType Directory -Path $outputAbs -Force | Out-Null
+
+& $buildScript `
+  -ManifestPath $localManifestAbs `
+  -DistDir $distAbs `
+  -OutputDir $outputAbs `
+  -ChecksumsFile $checksumsAbs
+
+$nupkg = Get-ChildItem -Path $outputAbs -Filter "surveiller.$chocoVersion*.nupkg" -ErrorAction SilentlyContinue |
+  Sort-Object LastWriteTime -Descending |
+  Select-Object -First 1
+if ($null -eq $nupkg) {
+  throw "generated nupkg not found in $outputAbs"
+}
+
+& choco uninstall $PackageName -y --no-progress | Out-Null
+
+& choco install $PackageName `
+  -y `
+  --pre `
+  --force `
+  --source $outputAbs `
+  --no-progress
+
+if ($LASTEXITCODE -ne 0) {
+  throw "choco install failed with exit code $LASTEXITCODE"
+}
+
+& $PackageName -version | Out-Null
+
+Write-Host "[packaging] choco smoke install passed for package $PackageName"

--- a/scripts/packaging/ci/smoke_dnf.sh
+++ b/scripts/packaging/ci/smoke_dnf.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=scripts/packaging/lib/common.sh
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  smoke_dnf.sh [options]
+
+Options:
+  --manifest <path>       Release manifest path (default: dist/release-manifest.json)
+  --dist-dir <path>       Dist directory (default: dist)
+  --repo-dir <path>       DNF repo output directory (default: <dist>/published/dnf-smoke)
+  --status-file <path>    Publish status path (default: <dist>/publication-status/smoke-dnf.json)
+  --package <name>        Package name to install (default: surveiller)
+  --attempt <number>      Attempt number for status payload (default: 1)
+  -h, --help              Show this help
+EOF
+}
+
+to_abs_path() {
+  local repo_root="$1"
+  local path="$2"
+  case "${path}" in
+    /*) printf '%s\n' "${path}" ;;
+    *) printf '%s\n' "${repo_root}/${path}" ;;
+  esac
+}
+
+run_as_root() {
+  if command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    "$@"
+  fi
+}
+
+main() {
+  local repo_root manifest_path dist_dir repo_dir status_file package_name attempt
+  local manifest_abs dist_abs repo_abs status_abs publish_script version repo_file baseurl
+
+  repo_root="$(packaging_repo_root)"
+  manifest_path="dist/release-manifest.json"
+  dist_dir="dist"
+  repo_dir=""
+  status_file=""
+  package_name="surveiller"
+  attempt="${ATTEMPT:-1}"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --manifest)
+        manifest_path="${2:-}"
+        shift 2
+        ;;
+      --dist-dir)
+        dist_dir="${2:-}"
+        shift 2
+        ;;
+      --repo-dir)
+        repo_dir="${2:-}"
+        shift 2
+        ;;
+      --status-file)
+        status_file="${2:-}"
+        shift 2
+        ;;
+      --package)
+        package_name="${2:-}"
+        shift 2
+        ;;
+      --attempt)
+        attempt="${2:-}"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        packaging_die "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  if [ -z "${repo_dir}" ]; then
+    repo_dir="${dist_dir}/published/dnf-smoke"
+  fi
+  if [ -z "${status_file}" ]; then
+    status_file="${dist_dir}/publication-status/smoke-dnf.json"
+  fi
+
+  manifest_abs="$(to_abs_path "${repo_root}" "${manifest_path}")"
+  dist_abs="$(to_abs_path "${repo_root}" "${dist_dir}")"
+  repo_abs="$(to_abs_path "${repo_root}" "${repo_dir}")"
+  status_abs="$(to_abs_path "${repo_root}" "${status_file}")"
+  publish_script="${SCRIPT_DIR}/../publish_dnf_repo.sh"
+
+  packaging_require_file "${manifest_abs}"
+  packaging_require_executable "${publish_script}"
+  packaging_require_command jq
+  packaging_require_command dnf
+  packaging_require_command createrepo_c
+
+  version="$(jq -r '.version // empty' "${manifest_abs}")"
+  [ -n "${version}" ] || packaging_die "manifest missing version"
+
+  "${publish_script}" \
+    --version "${version}" \
+    --manifest "${manifest_abs}" \
+    --dist-dir "${dist_abs}" \
+    --repo-dir "${repo_abs}" \
+    --dry-run false \
+    --attempt "${attempt}" \
+    --status-file "${status_abs}"
+
+  repo_file="/etc/yum.repos.d/surveiller-smoke.repo"
+  baseurl="file://${repo_abs}/packages"
+
+  cleanup() {
+    run_as_root rm -f "${repo_file}" || true
+  }
+  trap cleanup EXIT
+
+  {
+    printf '[surveiller-smoke]\n'
+    printf 'name=surveiller smoke repository\n'
+    printf 'baseurl=%s\n' "${baseurl}"
+    printf 'enabled=1\n'
+    printf 'gpgcheck=0\n'
+    printf 'repo_gpgcheck=0\n'
+  } | run_as_root tee "${repo_file}" >/dev/null
+
+  run_as_root dnf -y clean all
+  run_as_root dnf -y makecache
+  run_as_root dnf -y install "${package_name}"
+
+  "${package_name}" -version >/dev/null
+  packaging_log_info "dnf smoke install passed for package ${package_name}"
+}
+
+main "$@"
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added package manager installation instructions for apt, dnf, Homebrew, and Chocolatey to README and release notes
  * Documented package publication workflow and local verification procedures

* **Tests**
  * Added automated smoke tests for package installation across multiple platforms (Ubuntu, Fedora, macOS, Windows)

* **Chores**
  * Enhanced CI/CD workflows to automate package testing and include installation guidance in releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->