### PR TITLE
test: cover trailing --log-file parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,38 @@ import (
 
 var version = "0.0.2"
 
+func parseTrailingArgs(args []string, flagLogFile *cli.OptionalString) (string, error) {
+	// Handle flags that appear after the config file argument.
+	// Go's flag package stops parsing at the first non-flag argument,
+	// so we need to manually process remaining flags.
+	var configPath string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--log-file" || arg == "-log-file":
+			if i+1 >= len(args) {
+				return "", fmt.Errorf("missing value for --log-file")
+			}
+			if err := flagLogFile.Set(args[i+1]); err != nil {
+				return "", fmt.Errorf("invalid log-file value: %w", err)
+			}
+			i++ // Skip the next argument as it's the flag value.
+		case strings.HasPrefix(arg, "--log-file="):
+			if err := flagLogFile.Set(strings.TrimPrefix(arg, "--log-file=")); err != nil {
+				return "", fmt.Errorf("invalid log-file value: %w", err)
+			}
+		case strings.HasPrefix(arg, "-log-file="):
+			if err := flagLogFile.Set(strings.TrimPrefix(arg, "-log-file=")); err != nil {
+				return "", fmt.Errorf("invalid log-file value: %w", err)
+			}
+		case !strings.HasPrefix(arg, "-") && configPath == "":
+			configPath = arg
+		}
+	}
+
+	return configPath, nil
+}
+
 func main() {
 	var (
 		flagInterval       cli.OptionalDuration
@@ -63,40 +95,10 @@ func main() {
 		return
 	}
 
-	args := flag.Args()
-	// Handle flags that appear after the config file argument
-	// Go's flag package stops parsing at the first non-flag argument,
-	// so we need to manually process remaining flags
-	var configPath string
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if arg == "--log-file" || arg == "-log-file" {
-			if i+1 < len(args) {
-				if err := flagLogFile.Set(args[i+1]); err != nil {
-					fmt.Fprintf(os.Stderr, "invalid log-file value: %v\n", err)
-					os.Exit(1)
-				}
-				i++ // Skip the next argument as it's the flag value
-				continue
-			}
-			fmt.Fprintln(os.Stderr, "missing value for --log-file")
-			os.Exit(1)
-		} else if strings.HasPrefix(arg, "--log-file=") {
-			if err := flagLogFile.Set(strings.TrimPrefix(arg, "--log-file=")); err != nil {
-				fmt.Fprintf(os.Stderr, "invalid log-file value: %v\n", err)
-				os.Exit(1)
-			}
-		} else if strings.HasPrefix(arg, "-log-file=") {
-			if err := flagLogFile.Set(strings.TrimPrefix(arg, "-log-file=")); err != nil {
-				fmt.Fprintf(os.Stderr, "invalid log-file value: %v\n", err)
-				os.Exit(1)
-			}
-		} else if !strings.HasPrefix(arg, "-") {
-			// This is a non-flag argument (config file)
-			if configPath == "" {
-				configPath = arg
-			}
-		}
+	configPath, err := parseTrailingArgs(flag.Args(), &flagLogFile)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 
 	if configPath == "" {

--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ func main() {
 	configPath, err := parseTrailingArgs(flag.Args(), &flagLogFile)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		flag.Usage()
 		os.Exit(1)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -249,6 +249,25 @@ func TestParseTrailingArgs(t *testing.T) {
 			args:    []string{"surveiller.conf", "--log-file"},
 			wantErr: "missing value for --log-file",
 		},
+		{
+			name:           "single-dash log-file after config",
+			args:           []string{"surveiller.conf", "-log-file", "surveiller.log"},
+			wantConfigPath: "surveiller.conf",
+			wantLogFile:    "surveiller.log",
+			wantLogFileSet: true,
+		},
+		{
+			name:           "single-dash equals log-file after config",
+			args:           []string{"surveiller.conf", "-log-file=surveiller.log"},
+			wantConfigPath: "surveiller.conf",
+			wantLogFile:    "surveiller.log",
+			wantLogFileSet: true,
+		},
+		{
+			name:    "missing single-dash log-file value after config",
+			args:    []string{"surveiller.conf", "-log-file"},
+			wantErr: "missing value for --log-file",
+		},
 	}
 
 	for _, tt := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -216,6 +216,73 @@ func TestBuildOverrides_EmptyValues(t *testing.T) {
 	}
 }
 
+func TestParseTrailingArgs(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		wantConfigPath string
+		wantLogFile    string
+		wantLogFileSet bool
+		wantErr        string
+	}{
+		{
+			name:           "config only",
+			args:           []string{"surveiller.conf"},
+			wantConfigPath: "surveiller.conf",
+		},
+		{
+			name:           "log-file flag after config",
+			args:           []string{"surveiller.conf", "--log-file", "surveiller.log"},
+			wantConfigPath: "surveiller.conf",
+			wantLogFile:    "surveiller.log",
+			wantLogFileSet: true,
+		},
+		{
+			name:           "log-file equals syntax after config",
+			args:           []string{"surveiller.conf", "--log-file=surveiller.log"},
+			wantConfigPath: "surveiller.conf",
+			wantLogFile:    "surveiller.log",
+			wantLogFileSet: true,
+		},
+		{
+			name:    "missing log-file value after config",
+			args:    []string{"surveiller.conf", "--log-file"},
+			wantErr: "missing value for --log-file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var flagLogFile cli.OptionalString
+			configPath, err := parseTrailingArgs(tt.args, &flagLogFile)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error %q, got nil", tt.wantErr)
+				}
+				if err.Error() != tt.wantErr {
+					t.Fatalf("expected error %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if configPath != tt.wantConfigPath {
+				t.Fatalf("expected config path %q, got %q", tt.wantConfigPath, configPath)
+			}
+			logFile, ok := flagLogFile.Value()
+			if ok != tt.wantLogFileSet {
+				t.Fatalf("expected log-file set=%v, got %v", tt.wantLogFileSet, ok)
+			}
+			if logFile != tt.wantLogFile {
+				t.Fatalf("expected log-file %q, got %q", tt.wantLogFile, logFile)
+			}
+		})
+	}
+}
+
 func TestSignalContext(t *testing.T) {
 	ctx, cancel := signalContext()
 	defer cancel()


### PR DESCRIPTION
## Summary
- extract trailing argument parsing into a helper so the behavior is testable
- add regression coverage for `--log-file` after the config path
- assert `surveiller.conf --log-file` returns a missing-value error instead of silently continuing

## Verification
- `sudo docker run --rm -v /home/a14184/surveiller:/src -w /src golang:1.24 bash -lc '/usr/local/go/bin/go test .'`
- `sudo docker run --rm -v /home/a14184/surveiller:/src -w /src golang:1.24 bash -lc '/usr/local/go/bin/go test . -run TestParseTrailingArgs -v'`
- `sudo docker run --rm -v /home/a14184/surveiller:/src -w /src golang:1.24 bash -lc '/usr/local/go/bin/go run . example/surveiller.sample.conf --log-file >/tmp/stdout 2>/tmp/stderr; code=$?; echo EXIT:$code; echo ---STDERR---; cat /tmp/stderr; echo ---STDOUT---; cat /tmp/stdout'`

## Notes
- `go test ./...` is currently red on `main` as well because `internal/ping` fails in `TestICMPPingerTimeout`; this PR does not touch that area.

Closes #34


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved command-line argument parsing with enhanced error reporting to stderr and proper exit code handling.

* **Tests**
  * Added unit tests to validate argument parsing behavior across multiple input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->