### PR TITLE
chore: prepare v0.0.12 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,36 +196,33 @@ jobs:
         ### Package Managers
 
         \`\`\`bash
-        # apt
-        sudo tee /etc/apt/sources.list.d/surveiller.list >/dev/null <<'APT'
-        deb [trusted=yes] <apt-repo-url> stable main
-        APT
-        sudo apt update
-        sudo apt install -y surveiller
+        # apt (Debian/Ubuntu)
+        VERSION="${VERSION}"
+        VERSION_NO_V="\${VERSION#v}"
+        ARCH="\$(dpkg --print-architecture)"
+        DEB_FILE="surveiller_\${VERSION_NO_V}_\${ARCH}.deb"
+        curl -fsSL -o "/tmp/\${DEB_FILE}" "https://github.com/doridoridoriand/surveiller/releases/download/\${VERSION}/\${DEB_FILE}"
+        sudo apt install -y "/tmp/\${DEB_FILE}"
 
-        # dnf
-        sudo tee /etc/yum.repos.d/surveiller.repo >/dev/null <<'DNF'
-        [surveiller]
-        name=surveiller
-        baseurl=<dnf-repo-url>/packages
-        enabled=1
-        gpgcheck=0
-        repo_gpgcheck=0
-        DNF
-        sudo dnf makecache
-        sudo dnf install -y surveiller
+        # dnf (Fedora/RHEL family)
+        VERSION="${VERSION}"
+        VERSION_NO_V="\${VERSION#v}"
+        ARCH="\$(uname -m)" # x86_64 or aarch64
+        RPM_FILE="surveiller-\${VERSION_NO_V}-1.\${ARCH}.rpm"
+        curl -fsSL -o "/tmp/\${RPM_FILE}" "https://github.com/doridoridoriand/surveiller/releases/download/\${VERSION}/\${RPM_FILE}"
+        sudo dnf install -y "/tmp/\${RPM_FILE}"
 
-        # Homebrew
-        brew tap ${REPO_OWNER}/homebrew-tap
-        brew install ${REPO_OWNER}/homebrew-tap/surveiller
+        # Homebrew (macOS/Linux)
+        VERSION="${VERSION}"
+        brew install "https://github.com/doridoridoriand/surveiller/releases/download/\${VERSION}/surveiller.rb"
         \`\`\`
 
         \`\`\`powershell
         # Chocolatey community feed
         choco install surveiller -y
 
-        # or private feed
-        choco install surveiller -y --source="'<choco-feed-url>'"
+        # or explicit community feed
+        choco install surveiller -y --source="'https://community.chocolatey.org/api/v2/'"
         \`\`\`
         
         ### Quick Install (Linux/macOS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12] - 2026-06-04
+
+### Changed
+- Update GitHub Release package-manager instructions to use downloadable release assets.
+- Update README package-manager examples for the v0.0.12 release.
+- Correct release process documentation for the current release script behavior.
+
+### Fixed
+- Print usage when trailing `--log-file`/`-log-file` is missing a value after the config file argument.
+- Support and test single-dash trailing `-log-file` forms consistently.
+- Rebuild Chocolatey packages with native `choco pack` before publishing.
+- Capture Chocolatey push diagnostics and write successful publication status reliably.
+
 ## [0.0.11] - 2026-03-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Package-manager distribution is supported for `apt`, `dnf`, `brew`, and `choco`.
 #### APT (Debian/Ubuntu)
 
 ```bash
-VERSION="v0.0.11"
+VERSION="v0.0.12"
 VERSION_NO_V="${VERSION#v}"
 ARCH="$(dpkg --print-architecture)"
 DEB_FILE="surveiller_${VERSION_NO_V}_${ARCH}.deb"
@@ -58,7 +58,7 @@ sudo apt install -y "/tmp/${DEB_FILE}"
 #### DNF (Fedora/RHEL family)
 
 ```bash
-VERSION="v0.0.11"
+VERSION="v0.0.12"
 VERSION_NO_V="${VERSION#v}"
 ARCH="$(uname -m)" # x86_64 or aarch64
 RPM_FILE="surveiller-${VERSION_NO_V}-1.${ARCH}.rpm"
@@ -70,7 +70,7 @@ sudo dnf install -y "/tmp/${RPM_FILE}"
 #### Homebrew (macOS/Linux)
 
 ```bash
-VERSION="v0.0.11"
+VERSION="v0.0.12"
 brew install \
   "https://github.com/doridoridoriand/surveiller/releases/download/${VERSION}/surveiller.rb"
 ```

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -23,9 +23,9 @@ Releases are automated using GitHub Actions. When a version tag is pushed, the C
 The script will:
 - Validate the version format
 - Check that you're on a clean working directory
-- Update the version in `main.go`
+- Fetch latest remote state and update local `main`
 - Run tests to ensure everything works
-- Commit the version change
+- Build and test the binary
 - Create and push the git tag
 - Trigger the automated release process
 
@@ -33,7 +33,7 @@ The script will:
 
 1. **Update version in main.go**
    ```go
-   const version = "0.0.1"  // Remove the 'v' prefix
+   var version = "0.0.1"  // Remove the 'v' prefix
    ```
 
 2. **Run tests**

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/doridoridoriand/surveiller/internal/ui"
 )
 
-var version = "0.0.2"
+var version = "0.0.12"
 
 func parseTrailingArgs(args []string, flagLogFile *cli.OptionalString) (string, error) {
 	// Handle flags that appear after the config file argument.


### PR DESCRIPTION
## Summary
- add v0.0.12 changelog entry
- update README and default version for v0.0.12
- align generated GitHub Release package installation notes with downloadable release assets
- correct release script documentation

## Verification
- make test-all
- make build && ./bin/surveiller -version
- rm -rf dist && make release

Note: local package smoke was not run because nfpm and pwsh are not installed locally; package build and install checks run in GitHub Actions.