### PR TITLE
fix: #46 #48 #52 #57 #58 #60 — handle leak, goroutine leak, thread-safety, validation, stdlib min/max

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
@@ -20,6 +21,10 @@ func (e *ConfigError) Error() string {
 }
 
 func (e *ConfigError) Unwrap() error { return e.Err }
+
+func (e *ConfigError) Is(target error) bool {
+	return errors.Is(e.Err, target)
+}
 
 // MetricsMode describes the granularity of metrics (future use).
 type MetricsMode string

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sync"
 	"time"
 )
 
@@ -26,6 +27,7 @@ var levelNames = map[Level]string{
 
 // Logger provides structured logging
 type Logger struct {
+	mu     sync.Mutex
 	level  Level
 	output io.Writer
 }
@@ -50,11 +52,15 @@ func NewLogger(level Level) *Logger {
 
 // SetOutput sets the output writer for the logger
 func (l *Logger) SetOutput(w io.Writer) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	l.output = w
 }
 
 // SetLevel sets the log level
 func (l *Logger) SetLevel(level Level) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	l.level = level
 }
 
@@ -63,9 +69,12 @@ func (l *Logger) log(level Level, message string, fields map[string]interface{})
 	if level < l.level {
 		return
 	}
+	l.mu.Lock()
 	if l.output == nil || l.output == io.Discard {
+		l.mu.Unlock()
 		return
 	}
+	defer l.mu.Unlock()
 
 	entry := LogEntry{
 		Timestamp: time.Now().Format(time.RFC3339),

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 
@@ -100,6 +101,11 @@ func escapeLabel(value string) string {
 
 // Serve starts an HTTP server and blocks until context cancellation.
 func Serve(ctx context.Context, addr string, mode config.MetricsMode, store state.Store) error {
+	// Validate address early
+	if _, _, err := net.SplitHostPort(addr); err != nil {
+		return fmt.Errorf("invalid metrics listen address %q: %w", addr, err)
+	}
+
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", NewServer(mode, store).Handler())
 	server := &http.Server{

--- a/internal/ping/external.go
+++ b/internal/ping/external.go
@@ -75,10 +75,10 @@ func pingArgs(addr string, timeout time.Duration) []string {
 			// macOS ping6 doesn't support -W option, timeout is handled by context
 			return []string{"-n", "-c", "1", addr}
 		}
-		timeoutMs := maxInt(100, int(timeout.Milliseconds()))
+		timeoutMs := max(100, int(timeout.Milliseconds()))
 		return []string{"-n", "-c", "1", "-W", strconv.Itoa(timeoutMs), addr}
 	default:
-		timeoutSec := maxInt(1, int(timeout.Seconds()+0.5))
+		timeoutSec := max(1, int(timeout.Seconds()+0.5))
 		return []string{"-n", "-c", "1", "-W", strconv.Itoa(timeoutSec), addr}
 	}
 }
@@ -93,11 +93,4 @@ func parseRTT(output []byte) time.Duration {
 		return 0
 	}
 	return time.Duration(value * float64(time.Millisecond))
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/internal/ping/external_test.go
+++ b/internal/ping/external_test.go
@@ -17,10 +17,10 @@ func TestPingArgs(t *testing.T) {
 	var expected []string
 	switch runtime.GOOS {
 	case "darwin":
-		timeoutMs := maxInt(100, int(timeout.Milliseconds()))
+		timeoutMs := max(100, int(timeout.Milliseconds()))
 		expected = []string{"-n", "-c", "1", "-W", strconv.Itoa(timeoutMs), "example.com"}
 	default:
-		timeoutSec := maxInt(1, int(timeout.Seconds()+0.5))
+		timeoutSec := max(1, int(timeout.Seconds()+0.5))
 		expected = []string{"-n", "-c", "1", "-W", strconv.Itoa(timeoutSec), "example.com"}
 	}
 
@@ -58,15 +58,6 @@ func TestParseRTTInvalid(t *testing.T) {
 	output := []byte("no time here\n")
 	if rtt := parseRTT(output); rtt != 0 {
 		t.Fatalf("expected zero RTT for missing pattern, got %v", rtt)
-	}
-}
-
-func TestMaxInt(t *testing.T) {
-	if maxInt(1, 2) != 2 {
-		t.Fatalf("expected maxInt to return 2")
-	}
-	if maxInt(5, -1) != 5 {
-		t.Fatalf("expected maxInt to return 5")
 	}
 }
 
@@ -303,7 +294,7 @@ func TestPingArgsIPv6(t *testing.T) {
 		// macOS ping6 doesn't support -W option, timeout is handled by context
 		expected = []string{"-n", "-c", "1", "::1"}
 	default:
-		timeoutSec := maxInt(1, int(timeout.Seconds()+0.5))
+		timeoutSec := max(1, int(timeout.Seconds()+0.5))
 		expected = []string{"-n", "-c", "1", "-W", strconv.Itoa(timeoutSec), "::1"}
 	}
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -191,8 +191,8 @@ func (u *UI) drawGroupBox(screen tcell.Screen, x, y, width, height int, group ta
 
 func (u *UI) formatTargetLine(width int, target state.TargetStatus) []styledRune {
 	statusStyle := statusStyle(target.Status)
-	name := padOrTrim(target.Name, minInt(14, width))
-	addr := padOrTrim(target.Address, minInt(18, width))
+	name := padOrTrim(target.Name, min(14, width))
+	addr := padOrTrim(target.Address, min(18, width))
 	status := padOrTrim(string(target.Status), 6)
 
 	rtt := padOrTrim(fmt.Sprintf("RTT:%s", formatRTT(target.LastRTT)), 12)
@@ -315,7 +315,7 @@ func flattenStyledText(parts []styledText, width int) []styledRune {
 	for _, part := range parts {
 		runes := []rune(part.text)
 		if used+len(runes) > width {
-			runes = runes[:maxInt(0, width-used)]
+			runes = runes[:max(0, width-used)]
 		}
 		result = append(result, styledRune{r: runes, style: part.style})
 		used += len(runes)
@@ -387,20 +387,6 @@ func statusStyle(status state.Status) tcell.Style {
 	default:
 		return tcell.StyleDefault.Foreground(tcell.ColorGray)
 	}
-}
-
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 func formatConfigInfo(cfg config.GlobalOptions) string {

--- a/main.go
+++ b/main.go
@@ -122,6 +122,7 @@ func main() {
 			os.Exit(1)
 		}
 		logger.SetOutput(logFile)
+		defer logFile.Close()
 	}
 
 	overrides := buildOverrides(flagInterval, flagTimeout, flagMaxConcurrency, flagMetricsMode, flagMetricsListen, flagNoUI)
@@ -272,7 +273,11 @@ func signalContext() (context.Context, context.CancelFunc) {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 	go func() {
-		<-ch
+		defer signal.Stop(ch)
+		select {
+		case <-ch:
+		case <-ctx.Done():
+		}
 		cancel()
 	}()
 	return ctx, cancel


### PR DESCRIPTION
## Summary

Fixes six issues across the codebase:

### #46: File handle leak in main.go
- `logFile` opened via `os.OpenFile` was never closed when the application exited
- Added `defer logFile.Close()` right after `logger.SetOutput(logFile)`

### #48: Goroutine leak in signalContext()
- The goroutine was only unblocked on signal receipt, never on context cancellation
- `signal.Stop(ch)` was never called, leaking the signal handler
- Changed the select to listen on both `ch` and `ctx.Done()`, and added `defer signal.Stop(ch)`

### #52: Logger not thread-safe for concurrent writes
- Added `sync.Mutex` to the Logger struct
- Locked around the marshal+write sequence in the `log` method
- Made `SetOutput` and `SetLevel` thread-safe

### #57: Validate metrics listen address before starting
- Added early validation using `net.SplitHostPort` in `metrics.Serve()`
- Returns a descriptive error if the address format is invalid

### #58: ConfigError should implement errors.Is()
- Added `Is(error) bool` method that delegates to `errors.Is(e.Err, target)`
- Enables proper sentinel error matching through ConfigError wrappers

### #60: Replace custom minInt/maxInt with stdlib min/max
- Replaced `maxInt` in `internal/ping/external.go` with stdlib `max`
- Replaced `minInt`/ in `internal/ui/ui.go` with stdlib `min`/
- Removed custom helper functions and updated tests

## Files changed
- `main.go` — #46, #48
- `internal/log/logger.go` — #52
- `internal/metrics/metrics.go` — #57
- `internal/config/types.go` — #58
- `internal/ping/external.go` — #60
- `internal/ping/external_test.go` — #60 (test updates)
- `internal/ui/ui.go` — #60

## Testing
- `make build` — passes
- `make test` — all tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Metrics server now validates the listen address before starting, preventing invalid configurations.
* Log files are now properly closed when the application exits, ensuring proper resource cleanup.

## Chores
* Removed obsolete test functions.
* Code refactoring to leverage built-in language utilities and improve thread safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->