### PR TITLE
[codex] fix external ping RTT handling

### DIFF
--- a/internal/ping/external.go
+++ b/internal/ping/external.go
@@ -23,31 +23,36 @@ func NewExternalPinger() *ExternalPinger {
 
 // Ping runs the system ping command and parses the RTT from stdout.
 func (p *ExternalPinger) Ping(ctx context.Context, addr string, timeout time.Duration) Result {
-	args := pingArgs(addr, timeout)
-	cmdName := pingCommand(addr)
-	start := time.Now()
+	isIPv6Addr := resolveIPv6(ctx, addr)
+	args := pingArgsFor(addr, timeout, isIPv6Addr)
+	cmdName := pingCommandFor(isIPv6Addr)
 	cmd := exec.CommandContext(ctx, cmdName, args...)
 	out, err := cmd.CombinedOutput()
+	return resultFromExternalPing(ctx, out, err)
+}
+
+func resultFromExternalPing(ctx context.Context, output []byte, err error) Result {
 	if err != nil {
-		// Check if context was cancelled due to timeout
-		if ctx.Err() == context.DeadlineExceeded {
-			return Result{Success: false, Error: fmt.Errorf("ping timeout: %w", ctx.Err())}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if ctxErr == context.DeadlineExceeded {
+				return Result{Success: false, Error: fmt.Errorf("ping timeout: %w", ctxErr)}
+			}
+			return Result{Success: false, Error: ctxErr}
 		}
 		return Result{Success: false, Error: fmt.Errorf("external ping failed: %w", err)}
 	}
 
-	rtt := parseRTT(out)
-	if rtt == 0 {
-		rtt = time.Since(start)
-		return Result{Success: true, RTT: rtt, Error: fmt.Errorf("RTT parse fallback: using wall clock as approximation")}
+	rtt, ok := parseRTTValue(output)
+	if !ok {
+		return Result{Success: false, Error: fmt.Errorf("external ping output did not contain RTT")}
 	}
 	return Result{Success: true, RTT: rtt}
 }
 
-// pingCommand returns the appropriate ping command name for the given address.
+// pingCommandFor returns the appropriate ping command name for an address family.
 // On macOS, IPv6 addresses require ping6 command.
-func pingCommand(addr string) string {
-	if runtime.GOOS == "darwin" && isIPv6(addr) {
+func pingCommandFor(isIPv6Addr bool) string {
+	if runtime.GOOS == "darwin" && isIPv6Addr {
 		return "ping6"
 	}
 	return "ping"
@@ -55,24 +60,26 @@ func pingCommand(addr string) string {
 
 // isIPv6 checks if the given address is an IPv6 address.
 func isIPv6(addr string) bool {
+	return resolveIPv6(context.Background(), addr)
+}
+
+func resolveIPv6(ctx context.Context, addr string) bool {
 	ip := net.ParseIP(addr)
 	if ip != nil {
 		return ip.To4() == nil
 	}
-	// Resolve with a limited resolver to avoid blocking on hung DNS
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+
+	lookupCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	resolver := &net.Resolver{PreferGo: true}
-	ips, err := resolver.LookupIPAddr(ctx, addr)
+	ips, err := resolver.LookupIPAddr(lookupCtx, addr)
 	if err != nil || len(ips) == 0 {
 		return false
 	}
 	return ips[0].IP.To4() == nil
 }
 
-func pingArgs(addr string, timeout time.Duration) []string {
-	isIPv6Addr := isIPv6(addr)
-
+func pingArgsFor(addr string, timeout time.Duration, isIPv6Addr bool) []string {
 	switch runtime.GOOS {
 	case "darwin":
 		if isIPv6Addr {
@@ -89,13 +96,18 @@ func pingArgs(addr string, timeout time.Duration) []string {
 }
 
 func parseRTT(output []byte) time.Duration {
+	rtt, _ := parseRTTValue(output)
+	return rtt
+}
+
+func parseRTTValue(output []byte) (time.Duration, bool) {
 	matches := timePattern.FindSubmatch(output)
 	if len(matches) < 2 {
-		return 0
+		return 0, false
 	}
 	value, err := strconv.ParseFloat(string(matches[1]), 64)
 	if err != nil {
-		return 0
+		return 0, false
 	}
-	return time.Duration(value * float64(time.Millisecond))
+	return time.Duration(value * float64(time.Millisecond)), true
 }

--- a/internal/ping/external_test.go
+++ b/internal/ping/external_test.go
@@ -196,7 +196,7 @@ func TestPingArgsVariousTimeouts(t *testing.T) {
 
 		// Verify basic structure
 		if len(args) < 5 {
-			t.Fatalf("expected at least 5 args for pingArgs(%q, %v), got %v", tc.addr, tc.timeout, args)
+			t.Fatalf("expected at least 5 args for pingArgsFor(%q, %v, false), got %v", tc.addr, tc.timeout, args)
 		}
 
 		// Verify address is included
@@ -274,7 +274,7 @@ func TestPingCommand(t *testing.T) {
 		for _, tc := range testCases {
 			result := pingCommandFor(tc.expected == "ping6")
 			if result != "ping" {
-				t.Fatalf("pingCommand(%q) = %q, expected %q on non-macOS", tc.addr, result, "ping")
+				t.Fatalf("pingCommandFor(%v) = %q, expected %q on non-macOS for %q", tc.expected == "ping6", result, "ping", tc.addr)
 			}
 		}
 		return
@@ -284,7 +284,7 @@ func TestPingCommand(t *testing.T) {
 	for _, tc := range testCases {
 		result := pingCommandFor(tc.expected == "ping6")
 		if result != tc.expected {
-			t.Fatalf("pingCommand(%q) = %q, expected %q", tc.addr, result, tc.expected)
+			t.Fatalf("pingCommandFor(%v) = %q, expected %q for %q", tc.expected == "ping6", result, tc.expected, tc.addr)
 		}
 	}
 }

--- a/internal/ping/external_test.go
+++ b/internal/ping/external_test.go
@@ -12,16 +12,16 @@ import (
 
 func TestPingArgs(t *testing.T) {
 	timeout := 1500 * time.Millisecond
-	args := pingArgs("example.com", timeout)
+	args := pingArgsFor("192.0.2.1", timeout, false)
 
 	var expected []string
 	switch runtime.GOOS {
 	case "darwin":
 		timeoutMs := max(100, int(timeout.Milliseconds()))
-		expected = []string{"-n", "-c", "1", "-W", strconv.Itoa(timeoutMs), "example.com"}
+		expected = []string{"-n", "-c", "1", "-W", strconv.Itoa(timeoutMs), "192.0.2.1"}
 	default:
 		timeoutSec := max(1, int(timeout.Seconds()+0.5))
-		expected = []string{"-n", "-c", "1", "-W", strconv.Itoa(timeoutSec), "example.com"}
+		expected = []string{"-n", "-c", "1", "-W", strconv.Itoa(timeoutSec), "192.0.2.1"}
 	}
 
 	if !reflect.DeepEqual(args, expected) {
@@ -31,7 +31,7 @@ func TestPingArgs(t *testing.T) {
 
 func TestPingArgsMinimumTimeout(t *testing.T) {
 	timeout := 10 * time.Millisecond
-	args := pingArgs("example.com", timeout)
+	args := pingArgsFor("192.0.2.1", timeout, false)
 
 	var expectedTimeout string
 	switch runtime.GOOS {
@@ -58,6 +58,19 @@ func TestParseRTTInvalid(t *testing.T) {
 	output := []byte("no time here\n")
 	if rtt := parseRTT(output); rtt != 0 {
 		t.Fatalf("expected zero RTT for missing pattern, got %v", rtt)
+	}
+}
+
+func TestResultFromExternalPingRejectsMissingRTT(t *testing.T) {
+	result := resultFromExternalPing(context.Background(), []byte("1 packets transmitted, 1 received\n"), nil)
+	if result.Success {
+		t.Fatalf("expected success output without RTT to be treated as failure")
+	}
+	if result.Error == nil || !strings.Contains(result.Error.Error(), "RTT") {
+		t.Fatalf("expected RTT parse error, got %v", result.Error)
+	}
+	if result.RTT != 0 {
+		t.Fatalf("expected zero RTT on parse failure, got %v", result.RTT)
 	}
 }
 
@@ -179,7 +192,7 @@ func TestPingArgsVariousTimeouts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		args := pingArgs(tc.addr, tc.timeout)
+		args := pingArgsFor(tc.addr, tc.timeout, false)
 
 		// Verify basic structure
 		if len(args) < 5 {
@@ -233,18 +246,10 @@ func TestIsIPv6(t *testing.T) {
 		{"::1", true},
 		{"2001:db8::1", true},
 		{"fe80::1", true},
-		{"localhost", false},   // Will resolve to IPv4 or IPv6 depending on system
-		{"example.com", false}, // Will resolve to IPv4 or IPv6 depending on system
 	}
 
 	for _, tc := range testCases {
 		result := isIPv6(tc.addr)
-		// For hostnames, we can't be certain, so we just check it doesn't panic
-		if tc.addr == "localhost" || tc.addr == "example.com" {
-			// Just verify it returns a boolean value without panicking
-			_ = result
-			continue
-		}
 		if result != tc.expected {
 			t.Fatalf("isIPv6(%q) = %v, expected %v", tc.addr, result, tc.expected)
 		}
@@ -267,7 +272,7 @@ func TestPingCommand(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		// On non-macOS systems, pingCommand should always return "ping"
 		for _, tc := range testCases {
-			result := pingCommand(tc.addr)
+			result := pingCommandFor(tc.expected == "ping6")
 			if result != "ping" {
 				t.Fatalf("pingCommand(%q) = %q, expected %q on non-macOS", tc.addr, result, "ping")
 			}
@@ -277,7 +282,7 @@ func TestPingCommand(t *testing.T) {
 
 	// On macOS, IPv6 addresses should use ping6
 	for _, tc := range testCases {
-		result := pingCommand(tc.addr)
+		result := pingCommandFor(tc.expected == "ping6")
 		if result != tc.expected {
 			t.Fatalf("pingCommand(%q) = %q, expected %q", tc.addr, result, tc.expected)
 		}
@@ -286,13 +291,13 @@ func TestPingCommand(t *testing.T) {
 
 func TestPingArgsIPv6(t *testing.T) {
 	timeout := 1500 * time.Millisecond
-	args := pingArgs("::1", timeout)
+	args := pingArgsFor("::1", timeout, true)
 
 	var expected []string
 	switch runtime.GOOS {
 	case "darwin":
-		// macOS ping6 doesn't support -W option, timeout is handled by context
-		expected = []string{"-n", "-c", "1", "::1"}
+		timeoutSec := max(1, int(timeout.Seconds()+0.5))
+		expected = []string{"-n", "-c", "1", "-t", strconv.Itoa(timeoutSec), "::1"}
 	default:
 		timeoutSec := max(1, int(timeout.Seconds()+0.5))
 		expected = []string{"-n", "-c", "1", "-W", strconv.Itoa(timeoutSec), "::1"}


### PR DESCRIPTION
## Summary

Fixes #48 and #49.

- resolve hostname address family once per external ping call using the caller context, then pass that result into command and argument construction
- stop treating successful ping output without an RTT as a successful result with wall-clock fallback latency
- add a focused regression test for missing RTT output
- remove DNS-dependent unit-test paths and align the macOS IPv6 argument expectation with the `-t` timeout behavior already in the implementation

## Root Cause

`ExternalPinger.Ping` built the command and arguments independently, causing address-family resolution to happen more than once. It also treated unparseable successful output as success by substituting `time.Since(start)`, which reports command duration rather than ICMP RTT.

## Validation

- `go test ./...`
- `go test -race ./internal/ping ./internal/scheduler`
- `go test -tags=property ./internal/ping`
- `go vet ./...`
- `staticcheck ./...`