### PR TITLE
[codex] fix target config option copying

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -54,6 +54,18 @@ type TargetConfig struct {
 	Options map[string]string
 }
 
+// Copy returns a deep copy of the target configuration.
+func (t TargetConfig) Copy() TargetConfig {
+	copied := t
+	if t.Options != nil {
+		copied.Options = make(map[string]string, len(t.Options))
+		for key, value := range t.Options {
+			copied.Options[key] = value
+		}
+	}
+	return copied
+}
+
 // Config is the parsed configuration file with global settings.
 type Config struct {
 	Targets []TargetConfig

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -1,0 +1,35 @@
+package config
+
+import "testing"
+
+func TestTargetConfigCopyDeepCopiesOptions(t *testing.T) {
+	original := TargetConfig{
+		Name:    "api",
+		Address: "192.0.2.10",
+		Group:   "edge",
+		Options: map[string]string{
+			"relay": "jump1",
+			"user":  "alice",
+		},
+	}
+
+	copied := original.Copy()
+	copied.Options["relay"] = "jump2"
+	copied.Options["new"] = "value"
+
+	if original.Options["relay"] != "jump1" {
+		t.Fatalf("original option was mutated: %q", original.Options["relay"])
+	}
+	if _, ok := original.Options["new"]; ok {
+		t.Fatalf("new option leaked into original: %+v", original.Options)
+	}
+}
+
+func TestTargetConfigCopyPreservesNilOptions(t *testing.T) {
+	original := TargetConfig{Name: "api", Address: "192.0.2.10"}
+	copied := original.Copy()
+
+	if copied.Options != nil {
+		t.Fatalf("expected nil options to remain nil, got %+v", copied.Options)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -46,7 +46,8 @@ func NewScheduler(global config.GlobalOptions, targets []config.TargetConfig, pi
 		targetJobs: make(map[string]context.CancelFunc),
 	}
 	for _, tgt := range targets {
-		s.targets[tgt.Name] = tgt
+		copied := tgt.Copy()
+		s.targets[copied.Name] = copied
 	}
 	return s
 }
@@ -63,7 +64,7 @@ func (s *Impl) Run(ctx context.Context) error {
 	s.runCtx = runCtx
 	targets := make([]config.TargetConfig, 0, len(s.targets))
 	for _, tgt := range s.targets {
-		targets = append(targets, tgt)
+		targets = append(targets, tgt.Copy())
 	}
 	s.mu.Unlock()
 
@@ -89,7 +90,8 @@ func (s *Impl) UpdateConfig(global config.GlobalOptions, targets []config.Target
 
 	updated := make(map[string]config.TargetConfig, len(targets))
 	for _, tgt := range targets {
-		updated[tgt.Name] = tgt
+		copied := tgt.Copy()
+		updated[copied.Name] = copied
 	}
 
 	runCtx := s.runCtx

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -74,6 +74,38 @@ func TestSchedulerUpdateConfigStartsNewTarget(t *testing.T) {
 	recorder.waitFor(t, "192.0.2.2", 1, ctx)
 }
 
+func TestSchedulerCopiesTargetOptions(t *testing.T) {
+	initialOptions := map[string]string{"relay": "jump1"}
+	initial := []config.TargetConfig{{
+		Name:    "a",
+		Address: "192.0.2.1",
+		Options: initialOptions,
+	}}
+
+	s := NewScheduler(config.GlobalOptions{
+		Interval:       time.Second,
+		Timeout:        time.Second,
+		MaxConcurrency: 1,
+	}, initial, &recordingPinger{seen: make(map[string]int)}, state.NewStore(nil, time.Second), nil)
+
+	initialOptions["relay"] = "mutated"
+	if got := s.targets["a"].Options["relay"]; got != "jump1" {
+		t.Fatalf("scheduler shared initial target options map, got %q", got)
+	}
+
+	updatedOptions := map[string]string{"relay": "jump2"}
+	s.UpdateConfig(s.cfg, []config.TargetConfig{{
+		Name:    "a",
+		Address: "192.0.2.1",
+		Options: updatedOptions,
+	}})
+
+	updatedOptions["relay"] = "mutated-again"
+	if got := s.targets["a"].Options["relay"]; got != "jump2" {
+		t.Fatalf("scheduler shared updated target options map, got %q", got)
+	}
+}
+
 type blockingPinger struct {
 	inFlight int32
 	max      int32


### PR DESCRIPTION
## Summary

Fixes #56.

- add `TargetConfig.Copy()` to deep-copy the `Options` map
- use `Copy()` when the scheduler stores and snapshots target configs
- add regression coverage for `TargetConfig.Copy()` and scheduler target option isolation

## Root Cause

`TargetConfig.Options` is a map, so ordinary value copies share the same mutable map. The scheduler stored incoming target values directly, which allowed later mutations of caller-owned option maps to leak into scheduler state.

## Validation

- `go test ./internal/config ./internal/scheduler`
- `go test -race ./internal/config ./internal/scheduler`
- `go vet ./...`
- `staticcheck ./...`

Note: `go test ./...` currently fails on macOS due to the existing macOS ping6 test expectation mismatch fixed separately in PR #64.