### PR TITLE
[codex] validate metrics listen config

### DIFF
--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bufio"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -189,11 +190,11 @@ func applyDirective(global *GlobalOptions, pairs map[string]string) error {
 				return fmt.Errorf("invalid metrics.mode %q (valid values: per-target, aggregated, both)", val)
 			}
 		case "metrics.listen":
-			if isDigits(val) {
-				global.MetricsListen = ":" + val
-			} else {
-				global.MetricsListen = val
+			listen := normalizeMetricsListen(val)
+			if err := validateMetricsListen(listen); err != nil {
+				return err
 			}
+			global.MetricsListen = listen
 		case "ui.scale":
 			n, err := strconv.Atoi(val)
 			if err != nil {
@@ -226,6 +227,9 @@ func validateGlobal(path string, global *GlobalOptions) error {
 	if global.UIScale <= 0 {
 		return &ConfigError{Path: path, Line: 0, Err: fmt.Errorf("ui.scale must be positive, got %d", global.UIScale)}
 	}
+	if err := validateMetricsListen(global.MetricsListen); err != nil {
+		return &ConfigError{Path: path, Line: 0, Err: err}
+	}
 	return nil
 }
 
@@ -256,15 +260,33 @@ func applyCLIOverrides(global *GlobalOptions, overrides CLIOverrides) {
 		global.MetricsMode = *overrides.MetricsMode
 	}
 	if overrides.MetricsListen != nil {
-		val := *overrides.MetricsListen
-		if isDigits(val) {
-			val = ":" + val
-		}
-		global.MetricsListen = val
+		global.MetricsListen = normalizeMetricsListen(*overrides.MetricsListen)
 	}
 	if overrides.UIDisable != nil {
 		global.UIDisable = *overrides.UIDisable
 	}
+}
+
+func normalizeMetricsListen(value string) string {
+	if isDigits(value) {
+		return ":" + value
+	}
+	return value
+}
+
+func validateMetricsListen(addr string) error {
+	if addr == "" {
+		return nil
+	}
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("invalid metrics.listen address %q: %w", addr, err)
+	}
+	portNum, err := strconv.Atoi(port)
+	if err != nil || portNum < 1 || portNum > 65535 {
+		return fmt.Errorf("invalid metrics.listen port %q in address %q", port, addr)
+	}
+	return nil
 }
 
 func isDigits(value string) bool {

--- a/internal/config/parser_test.go
+++ b/internal/config/parser_test.go
@@ -104,6 +104,51 @@ func TestLoadConfigParsesDirectiveWithoutComment(t *testing.T) {
 	}
 }
 
+func TestLoadConfigRejectsInvalidMetricsListen(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "missing_port", value: "localhost"},
+		{name: "non_numeric_port", value: ":abc"},
+		{name: "zero_port", value: ":0"},
+		{name: "too_large_port", value: "localhost:99999"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configText := "surveiller: metrics.listen=" + tt.value + "\n" +
+				"example 192.0.2.1\n"
+			path := writeTempConfig(t, configText)
+
+			_, err := SurveillerParser{}.LoadConfig(path, CLIOverrides{})
+			if err == nil {
+				t.Fatal("expected invalid metrics.listen error")
+			}
+			if !strings.Contains(err.Error(), "metrics.listen") {
+				t.Fatalf("expected metrics.listen in error, got %q", err.Error())
+			}
+			if !strings.Contains(err.Error(), ":1:") {
+				t.Fatalf("expected directive line number in error, got %q", err.Error())
+			}
+		})
+	}
+}
+
+func TestLoadConfigRejectsInvalidMetricsListenOverride(t *testing.T) {
+	configText := "example 192.0.2.1\n"
+	path := writeTempConfig(t, configText)
+	listen := "localhost:99999"
+
+	_, err := SurveillerParser{}.LoadConfig(path, CLIOverrides{MetricsListen: &listen})
+	if err == nil {
+		t.Fatal("expected invalid metrics listen override error")
+	}
+	if !strings.Contains(err.Error(), "metrics.listen") {
+		t.Fatalf("expected metrics.listen in error, got %q", err.Error())
+	}
+}
+
 func TestLoadConfigIgnoresComments(t *testing.T) {
 	configText := "" +
 		"# normal comment\n" +

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/doridoridoriand/surveiller/internal/ui"
 )
 
-var version = "0.0.12"
+var version = "devel"
 
 func parseTrailingArgs(args []string, flagLogFile *cli.OptionalString) (string, error) {
 	// Handle flags that appear after the config file argument.

--- a/main_test.go
+++ b/main_test.go
@@ -20,6 +20,12 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
+func TestVersionDefaultIsDevel(t *testing.T) {
+	if version != "devel" {
+		t.Fatalf("expected default version devel, got %q", version)
+	}
+}
+
 // 6.1 アプリケーション初期化の単体テスト
 func TestBuildOverrides(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Fixes #51, fixes #52, and fixes #57.

- default `main.version` to `devel` so release/local versions are injected with ldflags instead of source edits
- validate `metrics.listen` during config loading after normalizing numeric ports to `:port`
- reject malformed listen addresses and invalid ports before metrics server startup
- add regression coverage for invalid config directive values, invalid CLI overrides, and the default version value

## Root Cause

`metrics.listen` values were stored as strings and only failed later when the HTTP server attempted to bind. `main.version` also had a release-looking hardcoded default, making ldflags injection less clear for development builds.

## Validation

- `go test ./internal/config .`
- `go test -race ./internal/config .`
- `go test -tags=property ./internal/config`
- `go vet ./...`
- `staticcheck ./...`

Note: `go test ./...` currently fails on macOS due to the existing macOS ping6 test expectation mismatch fixed separately in PR #64.